### PR TITLE
Call use to register qt5agg as the backend

### DIFF
--- a/plotWindow.py
+++ b/plotWindow.py
@@ -1,5 +1,9 @@
 import matplotlib
+# prevent NoneType error for versions of matplotlib 3.1.0rc1+ by calling matplotlib.use()
+# For more on why it's nececessary, see
+# https://stackoverflow.com/questions/59656632/using-qt5agg-backend-with-matplotlib-3-1-2-get-backend-changes-behavior
 matplotlib.use('qt5agg')
+
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 import matplotlib.pyplot as plt

--- a/plotWindow.py
+++ b/plotWindow.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('qt5agg')
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This is a fix to issue #1. I am not quite sure why it works. Intuitively it makes sense that calling `matplotlib.use('qt5agg')` would perform some sort of registration. However, as I describe in [this stackoverflow question](https://stackoverflow.com/questions/59656632/using-qt5agg-backend-with-matplotlib-3-1-2-get-backend-changes-behavior), calling `matplotlib.get_backend()`, which simply returns a value from a dictionary works just as well.

To test, you can install a specific version of matplotlib using `pip3 install matplotlib==3.1.2`. Without this fix, running `python3 plotWindow.py` should fail. Incorporating the fix, `python3 plotWindow.py` should run as expected.